### PR TITLE
Fix errors

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -36,6 +36,10 @@
       url = "file+file:///dev/null";
       flake = false;
     };
+    rust-overlay.url = "github:oxalica/rust-overlay";
+    rust-overlay.inputs = {
+      nixpkgs.follows = "nixpkgs";
+    };
     fenix.url = "github:nix-community/fenix";
   };
 

--- a/nix/home/user/git.nix
+++ b/nix/home/user/git.nix
@@ -28,7 +28,7 @@
       ui = {
         default-command = "log";
         pager = ":builtin";
-        diff.tool = [
+        diff-formatter = [
           "delta"
           "--paging"
           "never"


### PR DESCRIPTION
Devenv apparently no longer includes oxalica/rust-overlay as an input, but since I use it, I have to include it myself.

Also fix a JJ deprecation.